### PR TITLE
feat: USER 엔티티 확장 및 카테고리(Enum) 기반 취향 정보 추가

### DIFF
--- a/module-api/user-service/src/main/java/com/roomhub/entity/User.java
+++ b/module-api/user-service/src/main/java/com/roomhub/entity/User.java
@@ -8,6 +8,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import com.roomhub.model.Language;
+import com.roomhub.model.Interest;
+import java.util.Set;
+import java.util.HashSet;
 import java.time.LocalDate;
 
 @Entity
@@ -44,8 +48,31 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private Role role;
 
-    private String provider; // google, kakao, naver
+    private String provider; // google
     private String providerId; // sub returned from provider
+
+    @Column(columnDefinition = "TEXT")
+    private String bio; // 자기소개
+
+    @Column(columnDefinition = "TEXT")
+    private String lifestyle; // 라이프스타일/성향
+
+    private String profileImage; // 프로필 이미지 URL
+
+    @Column(nullable = false)
+    private double trustScore = 50; // 신뢰 점수 (기본값 5점)
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "user_languages", joinColumns = @JoinColumn(name = "user_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "language")
+    private Set<Language> languages = new HashSet<>();
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "user_interests", joinColumns = @JoinColumn(name = "user_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "interest")
+    private Set<Interest> interests = new HashSet<>();
 
     // Email용 생성자
     public User(SubmitRequest dto, String phoneNumber) {

--- a/module-common/src/main/java/com/roomhub/model/Interest.java
+++ b/module-common/src/main/java/com/roomhub/model/Interest.java
@@ -1,0 +1,20 @@
+package com.roomhub.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Interest {
+    BOARD_GAME("Board Games"),
+    READING("Reading"),
+    HIKING("Hiking"),
+    COOKING("Cooking"),
+    TRAVELING("Traveling"),
+    PHOTOGRAPHY("Photography"),
+    MUSIC("Music"),
+    MOVIE("Movie"),
+    SPORTS("Sports");
+
+    private final String description;
+}

--- a/module-common/src/main/java/com/roomhub/model/Language.java
+++ b/module-common/src/main/java/com/roomhub/model/Language.java
@@ -1,0 +1,18 @@
+package com.roomhub.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Language {
+    KOREAN("Korean"),
+    ENGLISH("English"),
+    JAPANESE("Japanese"),
+    CHINESE("Chinese"),
+    FRENCH("French"),
+    GERMAN("German"),
+    SPANISH("Spanish");
+
+    private final String description;
+}


### PR DESCRIPTION


## 📌 개요
<!-- 해당 PR의 목적 및 배경을 설명해주세요. -->
기존 roomHub 프로젝트를 카우치 서핑 기반 프로젝트로 변경하기 위해서는 사용자의 신뢰감이 중요하기 때문에 사용자의 정보를 저장하는 컬럼을 추가함

## 🛠️ 작업 내용
<!-- 주요 변경 사항을 목록으로 작성해주세요. -->
USER 엔티티 확장 및 카테고리(Enum) 기반 취향 정보 추가
    - 카우치 서핑 모델 도입을 위한 bio, lifestyle, trustScore 필드 추가
    - 다중 선택 가능한 언어(Language) 및 관심사(Interset) Enum 시스템 구축
    - @ElementCollection을 활용한 매핑 테이블 설계로 다중 취향 정보 정규화

## 🧪 테스트 결과
<!-- 테스트 코드 작성 여부 및 로컬 테스트 결과를 상세히 작성해주세요. -->
- module-api 테스트 결과 pass

## 🔗 관련 이슈
<!-- close #이슈번호 형식으로 작성해주세요. -->
close #10 

## 📢 리뷰어에게 전달사항
<!-- 리뷰 시 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 작성해주세요. -->
