### PR TITLE
chore: PostgreSQL 데이터베이스 연동 및 Docker 개발 환경 구축(#18)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,10 @@ services:
     env_file:
       - .env
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/roomhub?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/roomhub
       SPRING_DATASOURCE_USERNAME: roomuser
       SPRING_DATASOURCE_PASSWORD: roompass
-      SPRING_JPA_HIBERNATE_DDL_AUTO: create
+      SPRING_JPA_HIBERNATE_DDL_AUTO: update
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       JWT_SECRET: ${JWT_SECRET}
@@ -53,7 +53,7 @@ services:
     env_file:
       - .env
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/roomhub?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/roomhub
       SPRING_DATASOURCE_USERNAME: roomuser
       SPRING_DATASOURCE_PASSWORD: roompass
       SPRING_JPA_HIBERNATE_DDL_AUTO: update
@@ -83,20 +83,19 @@ services:
         condition: service_started
 
   db:
-    image: mysql:8.1
+    image: postgres:16-alpine
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: roomhub
-      MYSQL_USER: roomuser
-      MYSQL_PASSWORD: roompass
+      POSTGRES_DB: roomhub
+      POSTGRES_USER: roomuser
+      POSTGRES_PASSWORD: roompass
     ports:
-      - "3307:3306"
+      - "5432:5432"
     healthcheck:
-      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-uroot", "-proot" ]
+      test: [ "CMD-SHELL", "pg_isready -U roomuser -d roomhub" ]
       interval: 5s
-      retries: 10
-      timeout: 3s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:alpine

--- a/module-api/reservation-service/build.gradle
+++ b/module-api/reservation-service/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     
-    runtimeOnly 'com.mysql:mysql-connector-j:8.3.0'
+    runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/module-api/reservation-service/src/main/resources/application.yml
+++ b/module-api/reservation-service/src/main/resources/application.yml
@@ -5,10 +5,10 @@ spring:
   application:
     name: reservation-service
   datasource:
-    url: jdbc:mysql://localhost:3306/roomhub_reservation?serverTimezone=Asia/Seoul&useSSL=false
-    username: root
-    password: 
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:postgresql://${DB_HOST:localhost}:5432/roomhub
+    username: ${DB_USERNAME:roomuser}
+    password: ${DB_PASSWORD:roompass}
+    driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
       ddl-auto: update

--- a/module-api/user-service/build.gradle
+++ b/module-api/user-service/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j:8.3.0'
+    runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/module-api/user-service/src/main/resources/application.properties
+++ b/module-api/user-service/src/main/resources/application.properties
@@ -3,17 +3,17 @@ server.port=8080
 
 aes.secret-key= OtmY8WaWxmbpWnm151qzEe48NbX/0N2FAeMIQcHmEGc=
 
-# MySQL
-spring.datasource.url=jdbc:mysql://db:3306/roomhub?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-spring.datasource.username=roomuser
-spring.datasource.password=roompass
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+# PostgreSQL
+spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:5432/roomhub
+spring.datasource.username=${DB_USERNAME:roomuser}
+spring.datasource.password=${DB_PASSWORD:roompass}
+spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.open-in-view=false
 
 # Spring Security & OAuth2

--- a/module-common/build.gradle
+++ b/module-common/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     api 'org.springframework.boot:spring-boot-starter-web'
     api 'org.springframework.boot:spring-boot-starter-data-redis'
+    runtimeOnly 'org.postgresql:postgresql'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
## 📌 개요
<!-- 해당 PR의 목적 및 배경을 설명해주세요. -->
- 프로젝트의 주 데이터베이스를 MySQL에서 PostgreSQL로 전환하고, 이를 위한 로컬 개발 환경(Docker)을 구축함.
- 프로젝트 전체 모듈의 데이터 베이스 연동 설정을 동기화함.
## 🛠️ 작업 내용
<!-- 주요 변경 사항을 목록으로 작성해주세요. -->
- 인프라 설정 ; docker-compose.yml에서 MySQL 서비스를 PostgreSQL16-alpine으로 교체 및 헬스 체크 설정 추가.
- 의존성 관리 : module-common 및 각 서비스 모듈의 build.gradle에서 MySQL드라이버 제거 및 postgresql 드라이버 추가.
- 애플리케이션 설정: user-service, reservation-service의 데이터소스 연결 정보(JDBC URL, Driver, Dialect)를 PostgreSQL 규격으로 업데이트.
- 환경 변수: .env 파일에 DB 연결 관련 공통 환경 변수(DB_HOST, DB_USERNAME, DB_PASSWORD) 도입.

## 🧪 테스트 결과
<!-- 테스트 코드 작성 여부 및 로컬 테스트 결과를 상세히 작성해주세요. -->
- docker-compose up -d db 명령으로 PostgreSQL 컨테이너 정상 가동 확인.
- pg_isready를 통한 컨테이너 헬스 체크 정상 작동 확인.
- user-service 및 reservation-service 애플리케이션 실행 시 PostgreSQL과 정상적으로 커넥션이 맺어지는 것 확인.(Hibernate DDL 자동 생성 로그 확인 완료).

## 🔗 관련 이슈
<!-- close #이슈번호 형식으로 작성해주세요. -->
close #18 
## 📢 리뷰어에게 전달사항
<!-- 리뷰 시 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 작성해주세요. -->
- 향후 위치 기반 데이터 처리를 위해 PostgreSQL의 PostGIS 확장 기능을 사용할 예정