### PR TITLE
feat: 유저 역할별 평판(별점 및 리뷰 횟수) 필드 추가 (#20)

### DIFF
--- a/module-api/user-service/src/main/java/com/roomhub/entity/User.java
+++ b/module-api/user-service/src/main/java/com/roomhub/entity/User.java
@@ -10,6 +10,8 @@ import lombok.Setter;
 
 import com.roomhub.model.Language;
 import com.roomhub.model.Interest;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.Set;
 import java.util.HashSet;
 import java.time.LocalDate;
@@ -60,7 +62,23 @@ public class User extends BaseTimeEntity {
     private String profileImage; // 프로필 이미지 URL
 
     @Column(nullable = false)
-    private double trustScore = 50; // 신뢰 점수 (기본값 5점)
+    private double trustScore = 50; // 신뢰 점수 (기본값 50점)
+
+    @Min(0)
+    @Max(5)
+    @Column(nullable = false)
+    private double hostRating = 0.0; // 호스트 평점
+
+    @Column(nullable = false)
+    private int hostReviewCount = 0; // 호스트 리뷰 개수
+
+    @Min(0)
+    @Max(5)
+    @Column(nullable = false)
+    private double guestRating = 0.0; // 게스트 평점
+
+    @Column(nullable = false)
+    private int guestReviewCount = 0; // 게스트 리뷰 개수
 
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "user_languages", joinColumns = @JoinColumn(name = "user_id"))


### PR DESCRIPTION
## 📌 개요
<!-- 해당 PR의 목적 및 배경을 설명해주세요. -->
- 유저 간의 신뢰를 측정하는 핵심 지표인 호스트/게스트 역할별 평점 시스템의 데이터 구조를 구축함.
- 단순히 숙박 시설을 넘어, '사람'  자체의 신뢰도를 관리하기  위한 기반 필드를 도입함.

## 🛠️ 작업 내용
<!-- 주요 변경 사항을 목록으로 작성해주세요. -->
- 엔티티 확장: User 엔티티에 hostRating, guestRating, hostReviewCount, guestReviewCount 필드 추가.
- 데이터 검증 보강: 별점의 신뢰도를 위해 5점 만점(@Max(5)) 및 최소 0점(@Min(0)) 범위를 제한하는 어노테이션 사용.
- 구조적 분리: 유저가 호스트일 때와 게스트일 때의 평판을 독립적으로 관리할 수 있도록 설계.
## 🧪 테스트 결과
<!-- 테스트 코드 작성 여부 및 로컬 테스트 결과를 상세히 작성해주세요. -->
- User 엔티티 클래스 수정 후 컴파일 및 빌드 정상 완료 확인.
- PostgreSQL 연동 환경에서 hibernate ddl-auto를 통해 해당 컬럼들이 DB 테이블에 정상적으로 생성되는 구조 확인.

## 🔗 관련 이슈
<!-- close #이슈번호 형식으로 작성해주세요. -->
close #20 

## 📢 리뷰어에게 전달사항
<!-- 리뷰 시 중점적으로 봐주었으면 하는 부분이나 궁금한 점을 작성해주세요. -->
- 현재 포함된 trustScore 필드는 향후 신분 인증(Verified 마크)이나 활동 실적 기반의 종합 신뢰 지표로 고도화할 계획이며, 이번 작업에서는 타인에 의한 평가인 '별점'데이터 구조에 집중했습니다.
- 향후 '슈퍼 호스트'등 칭호 시스템 구현시 이번에 추가된 hostReviewCount와 hostRating이 핵심 지표로 활용될 예정입니다.
